### PR TITLE
Reset movingMarker only if it has been set

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -198,7 +198,10 @@ var Select = L.Control.extend( /**  @lends Select.prototype */ {
       this._selection = null;
     }
 
-    this._movingMarker.setLatLng(this._layer.getLatLngs()[0]);
+    if (this._movingMarker) {
+      this._movingMarker.setLatLng(this._layer.getLatLngs()[0]);
+    }
+
     if (!this.options.useTouch) {
       //this._movingMarker.show();
       this._map.addLayer(this._movingMarker);


### PR DESCRIPTION
Hello,

I encountered a little error with your plugin, an error triggers when I want to cleanup leaflet with `map.remove()`.

In you plugin, this triggers the methods `onRemove` > `disable` > `reset`.

In my website, I require your plugin everytime, but I don't always use it, then sometimes `this._movingMarker` is still null when I call `map.remove()`.

This pull request checks `this._movingMarker` value before trying to reset its position.

Best regards, Oliv